### PR TITLE
Remove "archives" from sidebar

### DIFF
--- a/webquills/theme_bs4_2021/templates/components/blog_sidebar.html
+++ b/webquills/theme_bs4_2021/templates/components/blog_sidebar.html
@@ -7,24 +7,6 @@
 {% endif %}
 
 <div class="p-3">
-  <h4 class="font-italic">Archives</h4>
-  <ol class="list-unstyled mb-0">
-    <li><a href="#">March 2014</a></li>
-    <li><a href="#">February 2014</a></li>
-    <li><a href="#">January 2014</a></li>
-    <li><a href="#">December 2013</a></li>
-    <li><a href="#">November 2013</a></li>
-    <li><a href="#">October 2013</a></li>
-    <li><a href="#">September 2013</a></li>
-    <li><a href="#">August 2013</a></li>
-    <li><a href="#">July 2013</a></li>
-    <li><a href="#">June 2013</a></li>
-    <li><a href="#">May 2013</a></li>
-    <li><a href="#">April 2013</a></li>
-  </ol>
-</div>
-
-<div class="p-3">
   <h4 class="font-italic">Follow {{request.site.meta.name}}</h4>
   <ol class="list-unstyled">
     <li><a href="#">GitHub</a></li>


### PR DESCRIPTION
Can't think of anything useful to populate it with, so just removing the Archives section for now.